### PR TITLE
Change wgpu object drop order to fix memory leak

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,31 +49,30 @@ jobs:
 #      - name: Run tests
 #        run: cargo test --verbose
 
-# # Cleanup fails with: [__NSCFString bytes]: unrecognized selector sent to instance 0x600002fc62c0
-#  test-rs-macos:
-#    runs-on: macos-latest
-#    env:
-#      RUSTFLAGS: "-D warnings"
-#    steps:
-#      - name: Install Protoc
-#        uses: arduino/setup-protoc@v2
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      - uses: actions/checkout@v3
-#      - name: Install latest stable toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          prefix-key: "test-macos"
-#      - name: version
-#        run: rustc --version
-#      - name: test
-#        run:  cd avenger-wgpu/ && cargo test -- --nocapture
-#      - name: Update images
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: images-macos
-#          path: avenger-wgpu/tests/output
+  test-rs-macos:
+    runs-on: macos-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Install latest stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "test-macos"
+      - name: version
+        run: rustc --version
+      - name: test
+        run:  cd avenger-wgpu/ && cargo test -- --nocapture
+      - name: Update images
+        uses: actions/upload-artifact@v4
+        with:
+          name: images-macos
+          path: avenger-wgpu/tests/output

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,30 +49,31 @@ jobs:
 #      - name: Run tests
 #        run: cargo test --verbose
 
-  test-rs-macos:
-    runs-on: macos-latest
-    env:
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
-      - name: Install latest stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "test-macos"
-      - name: version
-        run: rustc --version
-      - name: test
-        run:  cd avenger-wgpu/ && cargo test -- --nocapture
-      - name: Update images
-        uses: actions/upload-artifact@v4
-        with:
-          name: images-macos
-          path: avenger-wgpu/tests/output
+# # Cleanup fails with: [__NSCFString bytes]: unrecognized selector sent to instance 0x600002fc62c0
+#  test-rs-macos:
+#    runs-on: macos-latest
+#    env:
+#      RUSTFLAGS: "-D warnings"
+#    steps:
+#      - name: Install Protoc
+#        uses: arduino/setup-protoc@v2
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - uses: actions/checkout@v3
+#      - name: Install latest stable toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          prefix-key: "test-macos"
+#      - name: version
+#        run: rustc --version
+#      - name: test
+#        run:  cd avenger-wgpu/ && cargo test -- --nocapture
+#      - name: Update images
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: images-macos
+#          path: avenger-wgpu/tests/output

--- a/avenger-wgpu/src/canvas.rs
+++ b/avenger-wgpu/src/canvas.rs
@@ -420,17 +420,20 @@ pub(crate) fn get_supported_sample_count(sample_flags: TextureFormatFeatureFlags
 }
 
 pub struct WindowCanvas<'window> {
-    window: Arc<Window>,
-    surface: Surface<'window>,
-    device: Device,
-    queue: Queue,
-    multisampled_framebuffer: TextureView,
     sample_count: u32,
     surface_config: SurfaceConfiguration,
     dimensions: CanvasDimensions,
     marks: Vec<MarkRenderer>,
     multi_renderer: Option<MultiMarkRenderer>,
     config: CanvasConfig,
+
+    // Order of properties determines drop order.
+    // Device must be dropped after the buffers and textures associated with marks
+    multisampled_framebuffer: TextureView,
+    queue: Queue,
+    device: Device,
+    surface: Surface<'window>,
+    window: Arc<Window>,
 }
 
 impl<'window> WindowCanvas<'window> {
@@ -623,20 +626,24 @@ impl<'window> Canvas for WindowCanvas<'window> {
 }
 
 pub struct PngCanvas {
-    device: Device,
-    queue: Queue,
-    multisampled_framebuffer: TextureView,
     sample_count: u32,
     marks: Vec<MarkRenderer>,
-    pub dimensions: CanvasDimensions,
-    pub texture_view: TextureView,
-    pub output_buffer: Buffer,
-    pub texture: Texture,
-    pub texture_size: Extent3d,
-    pub padded_width: u32,
-    pub padded_height: u32,
-    pub multi_renderer: Option<MultiMarkRenderer>,
-    pub config: CanvasConfig,
+    dimensions: CanvasDimensions,
+    texture_view: TextureView,
+    output_buffer: Buffer,
+    texture: Texture,
+    texture_size: Extent3d,
+    padded_width: u32,
+    padded_height: u32,
+    multi_renderer: Option<MultiMarkRenderer>,
+    config: CanvasConfig,
+
+    // The order of properties in a struct is the order in which items are dropped.
+    // wgpu seems to require that the device be dropped last, otherwise there is a resouce
+    // leak.
+    multisampled_framebuffer: TextureView,
+    queue: Queue,
+    device: Device,
 }
 
 impl PngCanvas {

--- a/avenger-wgpu/src/html_canvas.rs
+++ b/avenger-wgpu/src/html_canvas.rs
@@ -12,16 +12,19 @@ use wgpu::{
 };
 
 pub struct HtmlCanvasCanvas<'window> {
-    surface: Surface<'window>,
-    device: Device,
-    queue: Queue,
-    multisampled_framebuffer: TextureView,
     sample_count: u32,
     surface_config: SurfaceConfiguration,
     dimensions: CanvasDimensions,
     marks: Vec<MarkRenderer>,
     multi_renderer: Option<MultiMarkRenderer>,
     config: CanvasConfig,
+
+    // The order of properties determines that drop order and device must be dropped after
+    // the buffers and textures associated with marks.
+    multisampled_framebuffer: TextureView,
+    queue: Queue,
+    device: Device,
+    surface: Surface<'window>,
 }
 
 impl<'window> HtmlCanvasCanvas<'window> {


### PR DESCRIPTION
Previously, the Rust test suite was hitting a "Context leak detected, msgtracer returned -1" error and crash when running locally on macOS. I investigated this in wgpu in https://github.com/gfx-rs/wgpu/issues/5529.  The fix / workaround turned out to be to ensure that the `wgpu::Device` is dropped after the wgpu textures and buffers associated with marks. This is simply a matter of re-ordering the properties of the Canvas structs.