### PR TITLE
wasm vega renderer: Finish symbol mark support

### DIFF
--- a/avenger-vega-renderer/js/index.js
+++ b/avenger-vega-renderer/js/index.js
@@ -165,36 +165,76 @@ function importGroup(vegaGroup) {
     return groupMark;
 }
 
-function importSymbol(vegaSymbolMark) {
+function importSymbol(vegaSymbolMark, force_clip) {
     const len = vegaSymbolMark.items.length;
-    const symbolMark = new SymbolMark(len, vegaSymbolMark.clip, vegaSymbolMark.name);
+
+    const items = vegaSymbolMark.items;
+    const firstItem = items[0];
+    const firstShape = firstItem.shape ?? "circle";
+
+    const symbolMark = new SymbolMark(
+        len, vegaSymbolMark.clip || force_clip, vegaSymbolMark.name, vegaSymbolMark.zindex
+    );
+
+    if (firstShape === "stroke") {
+        // TODO: Handle line legends
+        return symbolMark
+    }
+
+    // Only include stroke_width if there is a stroke color
+    const firstHasStroke = firstItem.stroke != null;
+    let strokeWidth;
+    if (firstHasStroke) {
+        strokeWidth = firstItem.strokeWidth ?? 1;
+    }
+    symbolMark.set_stroke_width(strokeWidth);
 
     // Semi-required values get initialized
     const x = new Float32Array(len).fill(0);
     const y = new Float32Array(len).fill(0);
 
+    const fill = new Array(len);
+    let anyFill = false;
+
     const size = new Float32Array(len).fill(20);
     let anySize = false;
+
+    const stroke = new Array(len);
+    let anyStroke = false;
 
     const angle = new Float32Array(len).fill(0);
     let anyAngle = false;
 
-    const opacity = new Float32Array(len).fill(1);
-    let anyOpacity = false;
+    const zindex = new Float32Array(len).fill(0);
+    let anyZindex = false;
 
-    const fill = new Array(len).fill("");
-    let anyFill = false;
+    const fillOpacity = new Float32Array(len).fill(1);
+    const strokeOpacity = new Float32Array(len).fill(1);
 
     const shapes = new Array(len);
     let anyShape = false;
 
-    const items = vegaSymbolMark.items;
     items.forEach((item, i) => {
-        x[i] = item.x;
-        y[i] = item.y;
+        x[i] = item.x ?? 0;
+        y[i] = item.y ?? 0;
+
+        const baseOpacity = item.opacity ?? 1;
+        fillOpacity[i] = (item.fillOpacity ?? 1) * baseOpacity;
+        strokeOpacity[i] = (item.strokeOpacity ?? 1) * baseOpacity;
+
+        if (item.fill != null) {
+            fill[i] = item.fill;
+            anyFill ||= true;
+        }
+
         if (item.size != null) {
             size[i] = item.size;
             anySize = true;
+        }
+
+        if (item.stroke != null) {
+            stroke[i] = item.stroke;
+            anyStroke ||= true;
         }
 
         if (item.angle != null) {
@@ -202,14 +242,9 @@ function importSymbol(vegaSymbolMark) {
             anyAngle ||= true;
         }
 
-        if (item.opacity != null) {
-            opacity[i] = item.opacity;
-            anyOpacity ||= true;
-        }
-
-        if (item.fill != null) {
-            fill[i] = item.fill;
-            anyFill ||= true;
+        if (item.zindex != null) {
+            zindex[i] = item.zindex;
+            anyZindex ||= true;
         }
 
         if (item.shape != null) {
@@ -220,17 +255,26 @@ function importSymbol(vegaSymbolMark) {
 
     symbolMark.set_xy(x, y);
 
+    if (anyFill) {
+        const encoded = encodeStringArray(fill);
+        symbolMark.set_fill(encoded.values, encoded.indices, fillOpacity);
+    }
+
     if (anySize) {
         symbolMark.set_size(size);
+    }
+
+    if (anyStroke) {
+        const encoded = encodeStringArray(stroke);
+        symbolMark.set_stroke(encoded.values, encoded.indices, strokeOpacity);
     }
 
     if (anyAngle) {
         symbolMark.set_angle(angle);
     }
 
-    if (anyFill || anyOpacity) {
-        const encoded = encodeStringArray(fill);
-        symbolMark.set_fill(encoded.values, encoded.indices, opacity);
+    if (anyZindex) {
+        symbolMark.set_zindex(zindex);
     }
 
     if (anyShape) {

--- a/avenger-vega-renderer/src/builder.rs
+++ b/avenger-vega-renderer/src/builder.rs
@@ -19,18 +19,22 @@ pub struct SymbolMark {
 #[wasm_bindgen]
 impl SymbolMark {
     #[wasm_bindgen(constructor)]
-    pub fn new(len: u32, clip: bool, name: Option<String>) -> Self {
+    pub fn new(len: u32, clip: bool, name: Option<String>, zindex: Option<i32>) -> Self {
         Self {
             inner: RsSymbolMark {
                 len,
                 clip,
+                zindex,
                 name: name.unwrap_or_default(),
-                fill: EncodingValue::Scalar {
-                    value: ColorOrGradient::Color([0.0, 0.0, 1.0, 0.5]),
-                },
                 ..Default::default()
             },
         }
+    }
+
+    pub fn set_zindex(&mut self, zindex: Vec<i32>) {
+        let mut indices: Vec<usize> = (0..self.inner.len as usize).collect();
+        indices.sort_by_key(|i| zindex[*i]);
+        self.inner.indices = Some(indices);
     }
 
     pub fn set_xy(&mut self, x: Vec<f32>, y: Vec<f32>) {
@@ -46,8 +50,8 @@ impl SymbolMark {
         self.inner.angle = EncodingValue::Array { values: angle };
     }
 
-    pub fn set_zindex(&mut self, zindex: Option<i32>) {
-        self.inner.zindex = zindex;
+    pub fn set_stroke_width(&mut self, width: Option<f32>) {
+        self.inner.stroke_width = width;
     }
 
     pub fn set_stroke(
@@ -112,6 +116,11 @@ impl RuleMark {
             },
         }
     }
+
+    pub fn set_zindex(&mut self, zindex: Option<i32>) {
+        self.inner.zindex = zindex;
+    }
+
     pub fn set_xy(&mut self, x0: Vec<f32>, y0: Vec<f32>, x1: Vec<f32>, y1: Vec<f32>) {
         self.inner.x0 = EncodingValue::Array { values: x0 };
         self.inner.y0 = EncodingValue::Array { values: y0 };
@@ -155,6 +164,10 @@ impl TextMark {
         }
     }
 
+    pub fn set_zindex(&mut self, zindex: Option<i32>) {
+        self.inner.zindex = zindex;
+    }
+
     pub fn set_xy(&mut self, x: Vec<f32>, y: Vec<f32>) {
         self.inner.x = EncodingValue::Array { values: x };
         self.inner.y = EncodingValue::Array { values: y };
@@ -174,10 +187,6 @@ impl TextMark {
 
     pub fn set_indices(&mut self, indices: Vec<usize>) {
         self.inner.indices = Some(indices);
-    }
-
-    pub fn set_zindex(&mut self, zindex: i32) {
-        self.inner.zindex = Some(zindex);
     }
 
     pub fn set_text(&mut self, text: JsValue) -> Result<(), JsError> {

--- a/avenger-vega-renderer/test/test_baselines.py
+++ b/avenger-vega-renderer/test/test_baselines.py
@@ -53,10 +53,32 @@ def failures_path():
 @pytest.mark.parametrize(
     "category,spec_name,tolerance",
     [
-        ("symbol", "binned_scatter_circle", 0.0001),
         ("symbol", "binned_scatter_diamonds", 0.0001),
         ("symbol", "binned_scatter_square", 0.0001),
         ("symbol", "binned_scatter_triangle-down", 0.0001),
+        ("symbol", "binned_scatter_triangle-up", 0.0001),
+        ("symbol", "binned_scatter_triangle-left", 0.0001),
+        ("symbol", "binned_scatter_triangle-right", 0.0001),
+        ("symbol", "binned_scatter_triangle", 0.0001),
+        ("symbol", "binned_scatter_wedge", 0.0001),
+        ("symbol", "binned_scatter_arrow", 0.0001),
+        ("symbol", "binned_scatter_cross", 0.0001),
+        ("symbol", "binned_scatter_circle", 0.0001),
+        ("symbol", "binned_scatter_path", 0.0001),
+        ("symbol", "binned_scatter_path_star", 0.0001),
+        ("symbol", "binned_scatter_path_star", 0.0001),
+        ("symbol", "binned_scatter_cross_stroke", 0.0001),
+        ("symbol", "binned_scatter_circle_stroke", 0.0001),
+        ("symbol", "binned_scatter_circle_stroke_no_fill", 0.0001),
+        ("symbol", "binned_scatter_path_star_stroke_no_fill", 0.0001),
+        ("symbol", "scatter_transparent_stroke", 0.0001),
+        ("symbol", "scatter_transparent_stroke_star", 0.0001),
+        ("symbol", "scatter_transparent_stroke_star", 0.0001),
+        ("symbol", "wind_vector", 0.0001),
+        ("symbol", "wedge_angle", 0.0001),
+        ("symbol", "wedge_stroke_angle", 0.0001),
+        ("symbol", "zindex_circles", 0.0001),
+        ("symbol", "mixed_symbols", 0.0001),
     ],
 )
 def test_image_baselines(
@@ -105,8 +127,8 @@ class ComparisonResult:
 
 
 def compare(page: Page, spec: dict) -> ComparisonResult:
-    canvas_img = spec_to_image(page, spec, "canvas")
     avenger_img = spec_to_image(page, spec, "avenger")
+    canvas_img = spec_to_image(page, spec, "canvas")
     diff_img = Image.new("RGBA", canvas_img.size)
     mismatch = pixelmatch(canvas_img, avenger_img, diff_img, threshold=0.2)
     score = mismatch / (canvas_img.width * canvas_img.height)

--- a/avenger-vega-renderer/test/test_server/webpack.config.js
+++ b/avenger-vega-renderer/test/test_server/webpack.config.js
@@ -26,4 +26,9 @@ module.exports = {
       ],
     }),
   ],
+  devServer: {
+    client: {
+      overlay: false,  // Disabling the error overlay
+    },
+  },
 };

--- a/avenger-vega-test-data/vega-specs/gradients/residuals_colorscale.vg.json
+++ b/avenger-vega-test-data/vega-specs/gradients/residuals_colorscale.vg.json
@@ -10,7 +10,7 @@
   "data": [
     {
       "name": "source_0",
-      "url": "data/movies.json",
+      "url": "https://raw.githubusercontent.com/vega/vega-datasets/main/data/movies.json",
       "format": {"type": "json", "parse": {"Release Date": "date"}},
       "transform": [
         {"type": "filter", "expr": "datum['IMDB Rating'] != null"},

--- a/avenger-vega-test-data/vega-specs/gradients/symbol_radial_gradient.vg.json
+++ b/avenger-vega-test-data/vega-specs/gradients/symbol_radial_gradient.vg.json
@@ -9,7 +9,7 @@
   "data": [
     {
       "name": "source_0",
-      "url": "data/movies.json",
+      "url": "https://raw.githubusercontent.com/vega/vega-datasets/main/data/movies.json",
       "format": {"type": "json"},
       "transform": [
         {

--- a/avenger-vega-test-data/vega-specs/vl-convert/circle_binned_base_url.vg.json
+++ b/avenger-vega-test-data/vega-specs/vl-convert/circle_binned_base_url.vg.json
@@ -8,7 +8,7 @@
   "data": [
     {
       "name": "source_0",
-      "url": "data/movies.json",
+      "url": "https://raw.githubusercontent.com/vega/vega-datasets/main/data/movies.json",
       "format": {"type": "json"},
       "transform": [
         {


### PR DESCRIPTION
Support all symbol features (including gradients) through the wasm/js vega renderer