### PR TITLE
Build avenger-vega-renderer with wasmbuild and inline wasm as base64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__/
 /avenger-wasm/dist/
 /examples/deno_png/chart.png
 /avenger-vega-renderer/test/failures/
+/avenger-vega-renderer/lib/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,16 +377,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "avenger-vega-test-data"
-version = "0.0.3"
-dependencies = [
- "pollster",
- "serde_json",
- "vl-convert-rs",
-]
-
-[[package]]
-name = "avenger-wasm"
+name = "avenger-vega-renderer"
 version = "0.1.0"
 dependencies = [
  "avenger",
@@ -404,6 +395,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "wgpu",
+]
+
+[[package]]
+name = "avenger-vega-test-data"
+version = "0.0.3"
+dependencies = [
+ "pollster",
+ "serde_json",
+ "vl-convert-rs",
 ]
 
 [[package]]
@@ -7364,9 +7364,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/avenger-vega-renderer/Cargo.toml
+++ b/avenger-vega-renderer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "avenger-wasm"
+name = "avenger-vega-renderer"
 version = "0.1.0"
 edition = "2021"
 
@@ -19,7 +19,7 @@ lazy_static = "1.4.0"
 serde_json = "1.0.114"
 csscolorparser = "0.6.2"
 wasm-bindgen = { version = "=0.2.92" }
-wasm-bindgen-futures = "0.4.30"
+wasm-bindgen-futures = "0.4.42"
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 js-sys = "0.3.69"
 web-sys = { version = "0.3.69", features = [

--- a/avenger-vega-renderer/js/index.js
+++ b/avenger-vega-renderer/js/index.js
@@ -1,7 +1,9 @@
-import { AvengerCanvas, SceneGraph, GroupMark, SymbolMark, RuleMark, TextMark, scene_graph_to_png } from "../pkg/avenger_wasm.js";
+import { instantiate, AvengerCanvas, SceneGraph, GroupMark, SymbolMark, RuleMark, TextMark, scene_graph_to_png } from "../lib/avenger_vega_renderer.generated.js";
 import { Renderer, CanvasHandler, domClear, domChild } from 'vega-scenegraph';
 import { inherits } from 'vega-util';
 
+// Load wasm
+instantiate();
 
 function devicePixelRatio() {
     return typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;

--- a/avenger-vega-renderer/package.json
+++ b/avenger-vega-renderer/package.json
@@ -5,15 +5,8 @@
   "main": "js/index.js",
   "files": [
     "js/**/*.js",
-    "pkg/"
+    "lib/"
   ],
-
-  "scripts": {
-    "build": "rm -rf pkg && wasm-pack build && rm -rf dist/ && mkdir -p dist/ && cp -r js/ dist/js && cp -r pkg dist/ && cp package.json dist/ && rm dist/pkg/package.json dist/pkg/.gitignore",
-    "build-deno": "rm -rf pkg_deno && wasm-pack build --target=deno --features=deno --out-dir=pkg_deno && rm -rf dist_deno/ && mkdir -p dist_deno/ && cp -r js/ dist_deno/js && cp -r pkg_deno dist_deno/pkg && cp package.json dist_deno/ && rm dist_deno/pkg/.gitignore",
-    "pack": "npm run build && cd dist && npm pack",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "peerDependencies": {
     "vega-scenegraph": "^4.11.2",
     "vega-util": "^1.17.2"

--- a/avenger-vega-renderer/test/test_server/index.js
+++ b/avenger-vega-renderer/test/test_server/index.js
@@ -1,5 +1,5 @@
 import vegaEmbed from 'vega-embed';
-import { registerVegaRenderer } from 'avenger-wasm';
+import { registerVegaRenderer } from 'avenger-vega-renderer';
 import { renderModule } from 'vega-scenegraph';
 
 // Simple initial chart spec that will be replaced using playwright

--- a/avenger-vega-renderer/test/test_server/package-lock.json
+++ b/avenger-vega-renderer/test/test_server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "avenger-wasm": "../../dist",
+        "avenger-vega-renderer": "../../dist",
         "vega-embed": "^6.24.0"
       },
       "devDependencies": {
@@ -790,7 +790,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/avenger-wasm": {
+    "node_modules/avenger-vega-renderer": {
       "resolved": "../../dist",
       "link": true
     },

--- a/avenger-vega-renderer/test/test_server/package.json
+++ b/avenger-vega-renderer/test/test_server/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
   "dependencies": {
-    "avenger-wasm": "../../dist",
+    "avenger-vega-renderer": "../../dist",
     "vega-embed": "^6.24.0"
   },
   "devDependencies": {

--- a/examples/vega-renderer/index.js
+++ b/examples/vega-renderer/index.js
@@ -1,5 +1,5 @@
 import vegaEmbed from 'vega-embed';
-import { registerVegaRenderer, viewToPng } from 'avenger-wasm';
+import { registerVegaRenderer, viewToPng } from 'avenger-vega-renderer';
 import { renderModule } from 'vega-scenegraph';
 
 const carsData = require('./data/cars_40k.json');

--- a/examples/vega-renderer/package-lock.json
+++ b/examples/vega-renderer/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "avenger-wasm": "../../avenger-vega-renderer/dist",
+        "avenger-vega-renderer": "../../avenger-vega-renderer/dist",
         "vega-embed": "^6.24.0"
       },
       "devDependencies": {
@@ -780,7 +780,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/avenger-wasm": {
+    "node_modules/avenger-vega-renderer": {
       "resolved": "../../avenger-vega-renderer/dist",
       "link": true
     },

--- a/examples/vega-renderer/package.json
+++ b/examples/vega-renderer/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
   "dependencies": {
-    "avenger-wasm": "../../avenger-vega-renderer/dist",
+    "avenger-vega-renderer": "../../avenger-vega-renderer/dist",
     "vega-embed": "^6.24.0"
   },
   "devDependencies": {

--- a/pixi.lock
+++ b/pixi.lock
@@ -46,6 +46,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py312h9f69965_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/deno-1.42.4-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
@@ -230,9 +231,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/09/766e3cb038be997cef78a29cfd4ec5e9be739b8ea44a09c839a6da8cb55b/pixelmatch-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4d/fc/e7c1a8696911e5faaa5c480f649deccf633aa2a235c91664748471490576/playwright-1.43.0-py3-none-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/a5/5b/0cc789b59e8cc1bf288b38111d002d8c5917123194d45b29dcdac64723cc/pluggy-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/cc/5cea8a0a0d3deb90b5a0d39ad1a6a1ccaa40a9ea86d793eb8a49d32a6ed0/pyee-11.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/7e/c79cecfdb6aa85c6c2e3cf63afc56d0f165f24f5c66c03c695c4d9b84756/pytest-8.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/43/6b1debd95ecdf001bc46789a933f658da3f9738c65f32db3f4e8f2a4ca97/pytest-8.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/85/323568cd7f139551bd9b9a776e67ffbd5164a254870d27c3645ecc47a7d8/pytest_playwright-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
@@ -1059,6 +1060,18 @@ packages:
   - pkg:pypi/defusedxml
   size: 24062
   timestamp: 1615232388757
+- kind: conda
+  name: deno
+  version: 1.42.4
+  build: hce30654_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/deno-1.42.4-hce30654_0.conda
+  sha256: acc82de2eee688e20980d626968d42483213b83b42f8639b0a62790a2cc5bdb1
+  md5: 4a2721e4a844bbe2d77adc0e619d6870
+  license: MIT
+  license_family: MIT
+  size: 31284644
+  timestamp: 1713272113948
 - kind: conda
   name: entrypoints
   version: '0.4'
@@ -3296,14 +3309,14 @@ packages:
   url: https://files.pythonhosted.org/packages/4d/fc/e7c1a8696911e5faaa5c480f649deccf633aa2a235c91664748471490576/playwright-1.43.0-py3-none-macosx_11_0_arm64.whl
   sha256: e9ec21b141727392f630761c7f4dec46d80c98243614257cc501b64ff636d337
   requires_dist:
-  - greenlet ==3.0.3
-  - pyee ==11.1.0
+  - greenlet==3.0.3
+  - pyee==11.1.0
   requires_python: '>=3.8'
 - kind: pypi
   name: pluggy
-  version: 1.4.0
-  url: https://files.pythonhosted.org/packages/a5/5b/0cc789b59e8cc1bf288b38111d002d8c5917123194d45b29dcdac64723cc/pluggy-1.4.0-py3-none-any.whl
-  sha256: 7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981
+  version: 1.5.0
+  url: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
+  sha256: 44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
   requires_dist:
   - pre-commit ; extra == 'dev'
   - tox ; extra == 'dev'
@@ -3614,24 +3627,24 @@ packages:
   timestamp: 1661604969727
 - kind: pypi
   name: pytest
-  version: 8.1.1
-  url: https://files.pythonhosted.org/packages/4d/7e/c79cecfdb6aa85c6c2e3cf63afc56d0f165f24f5c66c03c695c4d9b84756/pytest-8.1.1-py3-none-any.whl
-  sha256: 2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7
+  version: 8.2.0
+  url: https://files.pythonhosted.org/packages/c4/43/6b1debd95ecdf001bc46789a933f658da3f9738c65f32db3f4e8f2a4ca97/pytest-8.2.0-py3-none-any.whl
+  sha256: 1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233
   requires_dist:
   - iniconfig
   - packaging
-  - pluggy <2.0, >=1.4
-  - exceptiongroup >=1.0.0rc8 ; python_version < '3.11'
-  - tomli >=1 ; python_version < '3.11'
+  - pluggy<2.0,>=1.5
+  - exceptiongroup>=1.0.0rc8 ; python_version < '3.11'
+  - tomli>=1 ; python_version < '3.11'
   - colorama ; sys_platform == 'win32'
-  - argcomplete ; extra == 'testing'
-  - attrs >=19.2 ; extra == 'testing'
-  - hypothesis >=3.56 ; extra == 'testing'
-  - mock ; extra == 'testing'
-  - pygments >=2.7.2 ; extra == 'testing'
-  - requests ; extra == 'testing'
-  - setuptools ; extra == 'testing'
-  - xmlschema ; extra == 'testing'
+  - argcomplete ; extra == 'dev'
+  - attrs>=19.2 ; extra == 'dev'
+  - hypothesis>=3.56 ; extra == 'dev'
+  - mock ; extra == 'dev'
+  - pygments>=2.7.2 ; extra == 'dev'
+  - requests ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  - xmlschema ; extra == 'dev'
   requires_python: '>=3.8'
 - kind: pypi
   name: pytest-base-url
@@ -3639,13 +3652,13 @@ packages:
   url: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
   sha256: 3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6
   requires_dist:
-  - pytest >=7.0.0
-  - requests >=2.9
-  - black >=22.1.0 ; extra == 'test'
-  - flake8 >=4.0.1 ; extra == 'test'
-  - pre-commit >=2.17.0 ; extra == 'test'
-  - pytest-localserver >=0.7.1 ; extra == 'test'
-  - tox >=3.24.5 ; extra == 'test'
+  - pytest>=7.0.0
+  - requests>=2.9
+  - black>=22.1.0 ; extra == 'test'
+  - flake8>=4.0.1 ; extra == 'test'
+  - pre-commit>=2.17.0 ; extra == 'test'
+  - pytest-localserver>=0.7.1 ; extra == 'test'
+  - tox>=3.24.5 ; extra == 'test'
   requires_python: '>=3.8'
 - kind: pypi
   name: pytest-playwright
@@ -3653,10 +3666,10 @@ packages:
   url: https://files.pythonhosted.org/packages/a1/85/323568cd7f139551bd9b9a776e67ffbd5164a254870d27c3645ecc47a7d8/pytest_playwright-0.4.4-py3-none-any.whl
   sha256: df306f3a60a8631a3cfde1b95a2ed5a89203a3408dfa1154de049ca7de87c90b
   requires_dist:
-  - playwright >=1.18
-  - pytest <9.0.0, >=6.2.4
-  - pytest-base-url <3.0.0, >=1.0.0
-  - python-slugify <9.0.0, >=6.0.0
+  - playwright>=1.18
+  - pytest<9.0.0,>=6.2.4
+  - pytest-base-url<3.0.0,>=1.0.0
+  - python-slugify<9.0.0,>=6.0.0
   requires_python: '>=3.8'
 - kind: conda
   name: python
@@ -3750,8 +3763,8 @@ packages:
   url: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
   sha256: 276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8
   requires_dist:
-  - text-unidecode >=1.3
-  - unidecode >=1.1.1 ; extra == 'unidecode'
+  - text-unidecode>=1.3
+  - unidecode>=1.1.1 ; extra == 'unidecode'
   requires_python: '>=3.7'
 - kind: conda
   name: python-tzdata

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,6 +11,20 @@ dev-py = { cmd = ["maturin", "develop", "-m", "avenger-python/Cargo.toml", "--re
 build-py = { cmd = ["maturin", "build", "-m", "avenger-python/Cargo.toml", "--sdist", "--release"]}
 bump-version = { cmd = ["python", "automation/bump_version.py"] }
 
+[tasks.build-vega-renderer]
+cwd = "avenger-vega-renderer"
+cmd = """
+rm -rf lib/ &&
+
+deno run -A jsr:@deno/wasmbuild@0.17.1 -p avenger-vega-renderer -p avenger-vega-renderer --sync &&
+
+rm -rf dist/ &&
+mkdir -p dist/ &&
+cp -r js dist/js &&
+cp -r lib dist/ &&
+cp package.json dist/
+"""
+
 [tasks.publish-rs]
 cmd = """
 cargo publish -p avenger &&
@@ -35,6 +49,7 @@ bokeh = ">=3.4.0,<3.5"
 pixi-pycharm = ">=0.0.3,<0.1"
 pillow = ">=10.3.0,<10.4"
 ruff = ">=0.3.7,<0.4"
+deno = ">=1.42.4,<1.43"
 
 [pypi-dependencies]
 pytest-playwright = "*"


### PR DESCRIPTION
Replaces wasm-pack with wasmbuild for building avenger-vega-renderer. wasmbuild has the option of inlining wasm as base64 directly in a .js file, which makes it possible to hide the complexity of loading wasm from consumers. Now, as far as consumers are concerned, avenger-vega-renderer is a standard JavaScript package. This will make integration into Vega-Altair and vl-convert much simpler.
