### PR TITLE
Fix deno example

### DIFF
--- a/avenger-vega-renderer/Cargo.toml
+++ b/avenger-vega-renderer/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = [ "cdylib", "rlib",]
 
 [features]
-deno = [ "avenger-wgpu/deno",]
-
+deno = [ "avenger-wgpu/deno", "wgpu/webgpu"]
+default = [ "wgpu/webgl" ]
 [dependencies]
 lazy_static = "1.4.0"
 serde_json = "1.0.114"
@@ -39,7 +39,7 @@ version = "0.0.4"
 [dependencies.wgpu]
 version = "0.19.3"
 default-features = false
-features = [ "wgsl", "webgl", "webgpu",]
+features = [ "wgsl" ]
 
 [dependencies.wasm-bindgen]
 version = "=0.2.92"

--- a/avenger-vega-renderer/js/index.js
+++ b/avenger-vega-renderer/js/index.js
@@ -170,7 +170,7 @@ export async function viewToPng(view) {
         );
     });
 
-    const sceneGraph = importScenegraph(vegaSceneGroups, width, height, origin);
+    const sceneGraph = await importScenegraph(vegaSceneGroups, width, height, origin);
     const png = await scene_graph_to_png(sceneGraph);
     return png;
 }

--- a/examples/deno_png/README.md
+++ b/examples/deno_png/README.md
@@ -3,13 +3,13 @@
 Build wasm package for Deno in `avenger-vega-renderer/`
 
 ```
-npm run build-deno
+pixi run build-vega-renderer-deno
 ```
 
 Then from this directory
 
 ```
-deno run --allow-net --allow-read --allow-write --unstable-webgpu export_png.js
+deno run --allow-net --allow-write --unstable-webgpu export_png.js
 ```
 
 This should generate a `chart.png` file in the current directory

--- a/examples/deno_png/export_png.js
+++ b/examples/deno_png/export_png.js
@@ -1,5 +1,5 @@
 import * as vega from "https://cdn.skypack.dev/pin/vega@v5.28.0-apQC2txkSWyYRCV9ipfx/mode=imports/optimized/vega.js"
-import * as avenger from "../../avenger-vega-renderer/dist_deno/js/index.js"
+import { viewToPng } from "../../avenger-vega-renderer/dist-deno/js/index.js"
 
 var spec = {
     "$schema": "https://vega.github.io/schema/vega/v5.json",
@@ -111,5 +111,5 @@ var spec = {
 
 const runtime = vega.parse(spec);
 const view = new vega.View(runtime, {renderer: 'none'});
-const png = await avenger.viewToPng(view);
+const png = await viewToPng(view);
 Deno.writeFile("chart.png", png);

--- a/pixi.toml
+++ b/pixi.toml
@@ -35,6 +35,20 @@ npm pack &&
 mv avenger-vega-renderer-*.tgz packed
 """
 
+[tasks.build-vega-renderer-deno]
+cwd = "avenger-vega-renderer"
+cmd = """
+rm -rf lib/ &&
+
+deno run -A jsr:@deno/wasmbuild@0.17.1 -p avenger-vega-renderer -p avenger-vega-renderer --no-default-features --features "deno" --sync &&
+
+rm -rf dist-deno/ &&
+mkdir -p dist-deno/ &&
+cp -r js dist-deno/js &&
+cp -r lib dist-deno/ &&
+cp package.json dist-deno/
+"""
+
 [tasks.publish-rs]
 cmd = """
 cargo publish -p avenger &&


### PR DESCRIPTION
Fix example of exporting chart to png inside Deno.  Will need to decide whether this will be published as a separate package, or as a subdir in the main package.  To save space, I removed the webgl flag when compiling for Deno.