### PR TITLE
Switch Vega renderer to always use WebGL, bump version to 0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avenger"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "image",
  "lyon_extra",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "avenger-python"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "avenger",
  "avenger-vega",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "avenger-vega"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "avenger",
  "cfg-if",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "avenger-vega-renderer"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "avenger",
  "avenger-vega",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "avenger-vega-test-data"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "pollster",
  "serde_json",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "avenger-wgpu"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "avenger",
  "avenger-vega",

--- a/avenger-python/Cargo.toml
+++ b/avenger-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avenger-python"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 license = "BSD-3-Clause"
 description = "Python API to Avenger visualization framework"
@@ -17,17 +17,17 @@ pollster = "0.3"
 [dependencies.avenger]
 path = "../avenger"
 features = [ "pyo3",]
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.avenger-vega]
 path = "../avenger-vega"
 features = [ "pyo3",]
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.avenger-wgpu]
 path = "../avenger-wgpu"
 features = [ "pyo3",]
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.pyo3]
 workspace = true

--- a/avenger-python/pyproject.toml
+++ b/avenger-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "avenger"
-version = "0.0.6"
+version = "0.0.7"
 readme = "README.md"
 description = "A Visualization Engine and Renderer"
 

--- a/avenger-vega-renderer/Cargo.toml
+++ b/avenger-vega-renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avenger-vega-renderer"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 
 [lib]
@@ -26,16 +26,16 @@ version = "0.1.1"
 
 [dependencies.avenger-vega]
 path = "../avenger-vega"
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.avenger]
 path = "../avenger"
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.avenger-wgpu]
 path = "../avenger-wgpu"
 default-features = false
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.wgpu]
 version = "0.19.3"

--- a/avenger-vega-renderer/package-lock.json
+++ b/avenger-vega-renderer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avenger-vega-renderer",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/avenger-vega-renderer/package.json
+++ b/avenger-vega-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avenger-vega-renderer",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "main": "js/index.js",
   "files": [

--- a/avenger-vega-test-data/Cargo.toml
+++ b/avenger-vega-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avenger-vega-test-data"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 
 [dependencies]

--- a/avenger-vega/Cargo.toml
+++ b/avenger-vega/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avenger-vega"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 description = "Utilities for importing Vega scenegraphs into Avenger"
 license = "BSD-3-Clause"
@@ -33,7 +33,7 @@ workspace = true
 
 [dependencies.avenger]
 path = "../avenger"
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.thiserror]
 workspace = true

--- a/avenger-wgpu/Cargo.toml
+++ b/avenger-wgpu/Cargo.toml
@@ -74,6 +74,7 @@ version = "1.0.111"
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.wgpu]
 version = "0.19.3"
+default-features = false
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.web-sys]
 version = "0.3.67"

--- a/avenger-wgpu/Cargo.toml
+++ b/avenger-wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avenger-wgpu"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 description = "WGPU rendering engine for the Avenger visualization framework"
 license = "BSD-3-Clause"
@@ -33,7 +33,7 @@ rstest = "0.18.2"
 
 [dependencies.avenger]
 path = "../avenger"
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.rayon]
 workspace = true
@@ -67,7 +67,7 @@ workspace = true
 [dev-dependencies.avenger-vega]
 path = "../avenger-vega"
 features = [ "image-request", "svg",]
-version = "0.0.6"
+version = "0.0.7"
 
 [dev-dependencies.serde_json]
 version = "1.0.111"

--- a/avenger/Cargo.toml
+++ b/avenger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avenger"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 description = "A visualization engine and renderer"
 license = "BSD-3-Clause"

--- a/examples/vega-renderer/package-lock.json
+++ b/examples/vega-renderer/package-lock.json
@@ -21,8 +21,11 @@
     },
     "../../avenger-vega-renderer/dist": {
       "name": "avenger-vega-renderer",
-      "version": "0.1.0",
+      "version": "0.0.6",
       "license": "ISC",
+      "devDependencies": {
+        "typescript": "^5"
+      },
       "peerDependencies": {
         "vega-scenegraph": "^4.11.2",
         "vega-util": "^1.17.2"


### PR DESCRIPTION
Updates the Vega renderer to always use WebGL, rather than rely on wgpu's logic to try WebGPU and then fall back to WebGL, which doesn't seem to always work. WebGL has the same performance in my testing.