### PR TITLE
Include the repository field

### DIFF
--- a/avenger-wgpu/Cargo.toml
+++ b/avenger-wgpu/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.7"
 edition = "2021"
 description = "WGPU rendering engine for the Avenger visualization framework"
 license = "BSD-3-Clause"
+repository = "https://github.com/jonmmease/avenger"
 
 [lib]
 crate-type = [ "cdylib", "rlib",]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.